### PR TITLE
Recommend using volumes by default instead of bind mounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,16 @@ services:
   core-keeper:
     image: escaping/core-keeper-dedicated
     volumes:
-      - ./server-files:/home/steam/core-keeper-dedicated
-      - ./server-data:/home/steam/core-keeper-data
+      - server-files:/home/steam/core-keeper-dedicated
+      - server-data:/home/steam/core-keeper-data
       - /tmp/.X11-unix:/tmp/.X11-unix
-    env_file:
+    environment:
       - ./core.env
     restart: always
     stop_grace_period: 2m
+volumes:
+    server-files:
+    server-data:
 ```
 
 Create a `core.env` file, it should contain the environment variables for the dedicated server, see configuration for reference. Example:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ services:
       - server-files:/home/steam/core-keeper-dedicated
       - server-data:/home/steam/core-keeper-data
       - /tmp/.X11-unix:/tmp/.X11-unix
-    environment:
+    env_file:
       - ./core.env
     restart: always
     stop_grace_period: 2m


### PR DESCRIPTION
Bind mounts come with a lot of permissions headaches so making the README.md recommend using volumes by default. Users who are advanced enough to know they need bind mounts can work out the permissions issues.