### PR TITLE
Fix permissions.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ ENV STEAMAPPDIR "${HOMEDIR}/${STEAMAPP}-dedicated"
 ENV STEAMAPPDATADIR "${HOMEDIR}/${STEAMAPP}-data"
 ENV DLURL https://raw.githubusercontent.com/escapingnetwork/core-keeper-dedicated
 
+VOLUME ${STEAMAPPDIR}
+
 COPY ./entry.sh ${HOMEDIR}/entry.sh
 COPY ./launch.sh ${HOMEDIR}/launch.sh
 
@@ -32,6 +34,9 @@ RUN set -x \
 	&& chown -R "${USER}:${USER}" "${HOMEDIR}/entry.sh" "${HOMEDIR}/launch.sh" "${STEAMAPPDIR}" "${STEAMAPPDATADIR}" \
 	&& rm -rf /var/lib/apt/lists/*
 
+RUN mkdir /tmp/.X11-unix \
+	&& chown -R "${USER}:${USER}" /tmp/.X11-unix
+
 
 ENV WORLD_INDEX=0 \
 	WORLD_NAME="Core Keeper Server" \
@@ -45,7 +50,5 @@ USER ${USER}
 
 # Switch to workdir
 WORKDIR ${HOMEDIR}
-
-VOLUME ${STEAMAPPDIR}
 
 CMD ["bash", "entry.sh"] 


### PR DESCRIPTION
This commit fixes two issues:

1. Moving the volume definition higher allows for the subsequent `mkdir` and `chmod` commands below to be set to `${USER}`.
2. Preempting creating the X11 (xvfb) socket directory and setting permissions to the docker run user `${USER}` allows the Xvfb command to succeed (albeit with a warning), and thus not requiring Xvfb to be installed and run from the client and host socket file shared via a volume.