### PR TITLE
Core Keeper 0.6.1.2.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,10 +39,13 @@ RUN mkdir /tmp/.X11-unix \
 ENV WORLD_INDEX=0 \
 	WORLD_NAME="Core Keeper Server" \
 	WORLD_SEED=0 \
+	WORLD_MODE=0 \
 	GAME_ID="" \
 	DATA_PATH="" \
 	MAX_PLAYERS=10 \
-	SEASON=0
+	SEASON=-1 \
+	SERVER_IP="" \
+    SERVER_PORT=""
 
 # Switch to user
 USER ${USER}

--- a/README.md
+++ b/README.md
@@ -48,12 +48,15 @@ Create a `core.env` file, it should contain the environment variables for the de
 WORLD_INDEX=0
 WORLD_NAME=Core Keeper Server
 WORLD_SEED=0
+WORLD_MODE=0
 GAME_ID=
 DATA_PATH=
 MAX_PLAYERS=10
 DISCORD=1
 DISCORD_HOOK=https://discord.com/api/webhooks/{id}/{token}
-SEASON=
+SEASON=-1
+SERVER_IP=
+SERVER_PORT=
 ```
 
 On the folder which contains the files run `docker-compose up -d`.
@@ -70,14 +73,17 @@ These are the arguments you can use to customize server behavior with default va
 WORLD_INDEX         Which world index to use.
 WORLD_NAME          The name to use for the server.
 WORLD_SEED          The seed to use for a new world. Set to 0 to generate random seed.
-GAME_ID             Game ID to use for the server. Need to be at least 23 characters and alphanumeric, excluding Y,y,x,0,O. Empty or not valid means a new ID will be generated at start.
+WORLD_MODE          Sets the world mode for the world. Can be Normal (0), Hard (1), Creative (2), Casual (4). NOTE: Changing between Creative and non-Creative worlds not currently supported.
+GAME_ID             Game ID to use for the server. Need to be at least 28 characters and alphanumeric, excluding Y,y,x,0,O. Empty or not valid means a new ID will be generated at start.
 DATA_PATH           Save file location. If not set it defaults to a sub-folder named "DedicatedServer" at the default Core Keeper save location.
 MAX_PLAYERS         Maximum number of players that will be allowed to connect to server.
 DISCORD             Enables discord webhook features witch sends GameID to a channel.
 DISCORD_HOOK        Webhook url (Edit channel > Integrations > Create Webhook).
-SEASON              Enables Seasonal Events. 0 is default, 1 is Easter, 2 is Halloween, 3 is Christmas.
+SEASON              Overrides current season by setting to any of None (0), Easter (1), Halloween (2), Christmas (3), Valentine (4), Anniversary (5), CherryBlossom (6). -1 is default setting where it is set depending on system date.
+SERVER_IP           Only used if port is set. Sets the address that the server will bind to.
+SERVER_PORT         What port to bind to. If not set, then the server will use the Steam relay network. If set the clients will connect to the server directly and the port needs to be open.
 ```
-
+                          
 ### Contributors
 <a href="https://github.com/escapingnetwork/core-keeper-dedicated/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=escapingnetwork/core-keeper-dedicated" />

--- a/launch.sh
+++ b/launch.sh
@@ -35,7 +35,23 @@ rm -f GameID.txt
 
 chmod +x ./CoreKeeperServer
 
-DISPLAY=:99 LD_LIBRARY_PATH="$LD_LIBRARY_PATH:../Steamworks SDK Redist/linux64/" ./CoreKeeperServer -batchmode -logfile -world "${WORLD_INDEX}" -worldname "${WORLD_NAME}" -worldseed "${WORLD_SEED}" -gameid "${GAME_ID}" -datapath "${STEAMAPPDATADIR}" -maxplayers "${MAX_PLAYERS}" -logfile CoreKeeperServerLog.txt -season "${SEASON}"&
+#Build Parameters
+declare -a params
+params=(-batchmode -logfile "CoreKeeperServerLog.txt")
+if [ ! -z "${WORLD_INDEX}" ]; then params=( "${params[@]}" -world "${WORLD_INDEX}" ); fi
+if [ ! -z "${WORLD_NAME}" ]; then params=( "${params[@]}" -worldname "\"${WORLD_NAME}\"" ); fi
+if [ ! -z "${WORLD_SEED}" ]; then params=( "${params[@]}" -worldseed "${WORLD_SEED}" ); fi
+if [ ! -z "${WORLD_MODE}" ]; then params=( "${params[@]}" -worldmode "${WORLD_MODE}" ); fi
+if [ ! -z "${GAME_ID}" ]; then params=( "${params[@]}" -gameid "\"${GAME_ID}\"" ); fi
+if [ ! -z "${DATA_PATH}" ]; then params=( "${params[@]}" -datapath "\"${DATA_PATH}\"" ); fi
+if [ ! -z "${MAX_PLAYERS}" ]; then params=( "${params[@]}" -maxplayers "${MAX_PLAYERS}" ); fi
+if [ ! -z "${SEASON}" ]; then params=( "${params[@]}" -season "${SEASON}" ); fi
+if [ ! -z "${SERVER_IP}" ]; then params=( "${params[@]}" -ip "\"${SERVER_IP}\"" ); fi
+if [ ! -z "${SERVER_PORT}" ]; then params=( "${params[@]}" -port "${SERVER_PORT}" ); fi
+
+echo "${params[@]}"
+
+DISPLAY=:99 LD_LIBRARY_PATH="$LD_LIBRARY_PATH:../Steamworks SDK Redist/linux64/" ./CoreKeeperServer "${params[@]}"&
 
 ckpid=$!
 


### PR DESCRIPTION
New environment variables WORLD_MODE, SERVER_IP, SERVER_PORT 
Additional values and new default value for SEASON

Changes based on the current README-File of Core Keeper Dedicated Server version 0.6.1.2
```
# Core Keeper Dedicated Server

This is the Linux dedicated server for Core Keeper version 0.6.1.2.

## How to run

You can start the server via the Steam, but the server can also be started without the Steam client.

You can use SteamCMD to download the server files without requiring a login:
steamcmd +login anonymous +app_update 1007 +app_update 1963720 +quit

The _launch.sh bash script can be used to start the server, or you can start the CoreKeeperServer application directly.  Note that apart from the parameters liste
d in the Configuration section, you need the -batchmode parameter (NOT -nographics since part of the procedural generation is done on the GPU). Currently the -bat
chmode argument doesn't seem to work on Linux, but since we are running via Xvfb anyway to allow the server to run on a headless machine it doesn't matter much. S
ee the _launch.sh script for reference.

A GameID.txt file will be created next to the executable containing the Game ID. If it doesn't appear you can check the log in the same location named CoreKeeperS
erverLog.txt for errors.

## Configuration

These are the arguments you can use to customize server behaviour with default values. They can also be found and changed in the ServerConfig.json file together w
ith the other save files.

-world 0                                Which world index to use.
-worldname "Core Keeper Server"         The name to use for the server.
-worldseed 0                            The seed to use for a new world. Set to 0 to generate random seed.
-gameid ""                              Game ID to use for the server. Needs to be at least 28 characters and alphanumeric, excluding Y,y,x,0,O. Empty or not valid means a new ID will be generated at start.
-datapath ""                            Save file location. If not set it defaults to a subfolder named "DedicatedServer" at the default Core Keeper save location.
-maxplayers 100                         Maximum number of players that will be allowed to connect to server.
-worldmode 0                            Sets the world mode for the world. Can be Normal (0), Hard (1), Creative (2), Casual (4). NOTE: Changing between Creative and non-Creative worlds not currently supported.
-port <unset>                           What port to bind to. If not set, then the server will use the Steam relay network. If set the clients will connect to the server directly and the port needs to be open.
-ip 0.0.0.0                             Only used if port is set. Sets the address that the server will bind to.
-season -1                              Overrides current season by setting to any of None (0), Easter (1), Halloween (2), Christmas (3), Valentine (4), Anniversary (5), CherryBlossom (6). -1 is default setting where it is set depending on system date.
```