### PR TITLE
feat(Dockerfile): add tini for init handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN dpkg --add-architecture i386
 RUN set -x \
 	&& apt-get update \
 	&& apt-get install -y --no-install-recommends --no-install-suggests \
-	xvfb mesa-utils libx32gcc-s1 lib32gcc-s1 build-essential libxi6 x11-utils \
+	xvfb mesa-utils libx32gcc-s1 lib32gcc-s1 build-essential libxi6 x11-utils tini \
 	&& mkdir -p "${STEAMAPPDIR}" \
 	&& mkdir -p "${STEAMAPPDATADIR}" \
 	&& chmod +x "${HOMEDIR}/entry.sh" \
@@ -54,5 +54,8 @@ USER ${USER}
 WORKDIR ${HOMEDIR}
 
 VOLUME ${STEAMAPPDIR}
+
+# Use tini as the entrypoint for signal handling
+ENTRYPOINT ["/usr/bin/tini", "--"]
 
 CMD ["bash", "entry.sh"]


### PR DESCRIPTION
Adds tini to support passing through application signals allowing server to stop without waiting for timeout.