### PR TITLE
Propagate signals to launch.sh and fully await shutdown

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -12,4 +12,4 @@ fi
 
 bash "${STEAMCMDDIR}/steamcmd.sh" +force_install_dir "$STEAMAPPDIR" +login anonymous +app_update "$STEAMAPPID" +app_update "$STEAMAPPID_TOOL" +quit
 
-bash "./launch.sh"
+exec bash "./launch.sh"

--- a/launch.sh
+++ b/launch.sh
@@ -9,8 +9,8 @@ ckpid=""
 function kill_corekeeperserver {
         if [[ ! -z "$ckpid" ]]; then
                 kill $ckpid
+                wait $ckpid
         fi
-        sleep 1
         if [[ ! -z "$xvfbpid" ]]; then
                 kill $xvfbpid
         fi


### PR DESCRIPTION
This fully completes the passing of docker shutdown signals to the game executable. (Completes #46) Prior to this, the signals were not being passed from `entry.sh` to `launch.sh`. Another alternative is to merely source `entry.sh` from `launch.sh` and make `launch.sh` the actual dockerfile command.

Also, after some testing, i noticed some lost progress when shutting down the world. Delaying the termination of xvfb by `wait`ing within the trap handler seemed to eliminate this problem for me.