### PR TITLE
Add container name to docker-compose.yml and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Create two directories where you want to run your server :
 
 ### Using Docker CLI:
 
-`docker run -d -e WORLD_NAME="Core Keeper Server" -e MAX_PLAYERS=5 -v $(pwd)/server-data:/home/steam/core-keeper-data --name core-keeper-dedicated escaping/core-keeper-dedicated`
+`docker run -d -e WORLD_NAME="Core Keeper Server" -e MAX_PLAYERS=5 -v $(pwd)/server-data:/home/steam/core-keeper-data --name core-keeper-dedicated --network host escaping/core-keeper-dedicated`
 
 ### Using Docker Compose
 Create a `docker-compose.yml` with the following content:

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ version: "3"
 
 services:
   core-keeper:
+    container_name: core-keeper-dedicated
     image: escaping/core-keeper-dedicated
     volumes:
       - server-files:/home/steam/core-keeper-dedicated

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Create two directories where you want to run your server :
 
 ### Using Docker CLI:
 
-`docker run -d -e WORLD_NAME="Core Keeper Server" -e MAX_PLAYERS=5 -v $(pwd)/server-data:/home/steam/core-keeper-data --name core-keeper-dedicated --network host escaping/core-keeper-dedicated`
+`docker run -d -e WORLD_NAME="Core Keeper Server" -e MAX_PLAYERS=5 -v $(pwd)/server-data:/home/steam/core-keeper-data --name core-keeper-dedicated escaping/core-keeper-dedicated`
 
 ### Using Docker Compose
 Create a `docker-compose.yml` with the following content:
@@ -37,7 +37,6 @@ services:
       - server-data:/home/steam/core-keeper-data
     env_file:
       - ./core.env
-    network_mode: "host"
     restart: always
     stop_grace_period: 2m
 volumes:

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ services:
       - server-data:/home/steam/core-keeper-data
     env_file:
       - ./core.env
+    network_mode: "host"
     restart: always
     stop_grace_period: 2m
 volumes:

--- a/docker-compose-example/docker-compose.yml
+++ b/docker-compose-example/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - server-data:/home/steam/core-keeper-data
     env_file:
       - ./core.env
+    network_mode: "host"
     restart: always
     stop_grace_period: 2m
 volumes:

--- a/docker-compose-example/docker-compose.yml
+++ b/docker-compose-example/docker-compose.yml
@@ -1,6 +1,7 @@
 version: "3"
 
 services:
+  container_name: core-keeper-dedicated
   core-keeper:
     image: escaping/core-keeper-dedicated
     volumes:

--- a/docker-compose-example/docker-compose.yml
+++ b/docker-compose-example/docker-compose.yml
@@ -9,7 +9,6 @@ services:
       - server-data:/home/steam/core-keeper-data
     env_file:
       - ./core.env
-    network_mode: "host"
     restart: always
     stop_grace_period: 2m
 volumes:


### PR DESCRIPTION
This pull request includes changes to the `README.md` and `docker-compose-example/docker-compose.yml` files to ensure consistency in the Docker container naming convention.

The container name is not included in the docker-compose.yml so by default it becomes `core-keeper_core-keeper_1` instead.

In which will cause the following line in `README.md` to fail since the container name is different:
`docker exec -it core-keeper-dedicated cat core-keeper-dedicated/GameID.txt`

As the container name is set by the docker run command with the `--name core-keeper-dedicated` argument but not in docker-compose.yml