### PR TITLE
Fixing the container name incorrectly placed outside of server block

### DIFF
--- a/docker-compose-example/docker-compose.yml
+++ b/docker-compose-example/docker-compose.yml
@@ -1,8 +1,8 @@
 version: "3"
 
 services:
-  container_name: core-keeper-dedicated
   core-keeper:
+    container_name: core-keeper-dedicated
     image: escaping/core-keeper-dedicated
     volumes:
       - server-files:/home/steam/core-keeper-dedicated


### PR DESCRIPTION
**Problem:**
The container name was not correctly placed within the service `core-keeper` block. Small fix to correct this 👍 

**Proof after moving the container name within the `core-keeper` object key:**

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/0fadf9cb-9ef0-43b4-8bb3-cf702d615ead">

> Please ignore the absolute paths on the volumes and ports within the service block. These were edited by me to match my needs.
