### PR TITLE
Update steamcmd-arm64 image for fixing RPI4.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Dockerfile that builds a Core Keeper Gameserver
 ###########################################################
 FROM cm2network/steamcmd:root AS base-amd64
-FROM --platform=arm64 sonroyaalmerol/steamcmd-arm64:root-2024-12-04 AS base-arm64
+FROM --platform=arm64 sonroyaalmerol/steamcmd-arm64:root-2024-12-08 AS base-arm64
 
 ARG TARGETARCH
 FROM base-${TARGETARCH}

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This image currently includes the following Box64 build variants for the followi
 
 - Generic [generic]
 - Raspberry Pi 3 [rpi3]
-- Raspberry Pi 4 [rpi4]
+- Raspberry Pi 4 [rpi4-pre3]
 - Raspberry Pi 5 (4K page size) [rpi5]
 - Raspberry Pi 5 (16K page size) [rpi5_16k]
 - M1 (M-Series) Mac [m1]


### PR DESCRIPTION
A new version of `sonroyaalmerol/steamcmd-arm64` has released that introduces a new enviroment for RPI4 that fixes the crash when the server starts running at a RPI4.