### PR TITLE
Fix parsing of char_name for webhook

### DIFF
--- a/scripts/logfile-parser.sh
+++ b/scripts/logfile-parser.sh
@@ -6,7 +6,7 @@ LogParser() {
     while IFS= read -r line; do
         echo "$line"
 
-        if [[ "$line" == *"] player "* ]]; then
+        if [[ "$line" == "[userid:"*"] player"*"connected islocalplayer="* ]]; then
 
             # Extract the steamid and character name
             steamid=$(echo "$line" | awk -F'[[]|[ :]+|[]]' '{print $3}')

--- a/scripts/logfile-parser.sh
+++ b/scripts/logfile-parser.sh
@@ -6,11 +6,11 @@ LogParser() {
     while IFS= read -r line; do
         echo "$line"
 
-        if [[ "$line" == *"is using new name"* ]]; then
+        if [[ "$line" == *"] player "* ]]; then
 
             # Extract the steamid and character name
             steamid=$(echo "$line" | awk -F'[[]|[ :]+|[]]' '{print $3}')
-            char_name=$(echo "$line" | awk -F'new name ' '{print $2}')
+            char_name=$(echo "$line" | awk -F'player | connected' '{print $2}')
             LogDebug "Character Name: $char_name ($steamid)"
 
             # Store character name for future use


### PR DESCRIPTION
This is for fixing the parsing of the `char_name`. On our discord server, we noticed, that some players were called `Unknown` with the webhook. After investigation and debugging, we found that the `char_name` was not parsed because the line (the following line) in the server's logs, which should contain the information, does not appear for these players, we don't know why.

`[userid:##########] is using new name ******`

But the previous line in the log file with all requested information was always displayed, so now the `char_name` is parsed from this new line:

`[userid:##########] player ****** connected islocalplayer=False`