### PR TITLE
Add 'activatecontent' parameter in support of 1.1.0 update

### DIFF
--- a/scripts/compile-parameters.sh
+++ b/scripts/compile-parameters.sh
@@ -31,5 +31,6 @@ add_param "-maxplayers" "${MAX_PLAYERS}"
 add_param "-season"     "${SEASON}"
 add_param "-ip"         "${SERVER_IP}"
 add_param "-port"       "${SERVER_PORT}"
+add_param "-activatecontent" "${ACTIVATE_CONTENT}"
 
 echo "${params[@]}"


### PR DESCRIPTION
Added a new parameter and env variable to allow for the `-activatecontent` parameter to enable new biomes for the Core Keeper 1.1.0 update.