### PR TITLE
Fix logfile-parser.sh

### DIFF
--- a/scripts/logfile-parser.sh
+++ b/scripts/logfile-parser.sh
@@ -6,7 +6,7 @@ LogParser() {
     while IFS= read -r line; do
         echo "$line"
 
-        if [[ "${DISCORD_PLAYER_JOIN_ENABLED,,}" == true ]] && [[ "$line" == "[userid:"*"] player"*"connected islocalplayer="* ]]; then
+        if [[ "$line" == "[userid:"*"] player"*"connected islocalplayer="* ]]; then
 
             # Extract the steamid and character name
             steamid=$(echo "$line" | awk -F'[[]|[ :]+|[]]' '{print $3}')
@@ -16,12 +16,15 @@ LogParser() {
             # Store character name for future use
             characters[$steamid]=$char_name
 
+            [[ "${DISCORD_PLAYER_JOIN_ENABLED,,}" == false ]] && continue
+
             # Build message from vars and send message
             message=$(char_name="$char_name" steamid="$steamid" envsubst <<<"$DISCORD_PLAYER_JOIN_MESSAGE")
             SendDiscordMessage "$DISCORD_PLAYER_JOIN_TITLE" "$message" "$DISCORD_PLAYER_JOIN_COLOR"
         fi
 
-        if [[ "${DISCORD_PLAYER_LEAVE_ENABLED,,}" == true ]] && [[ "$line" == *"Disconnected from userid:"* ]]; then
+        if [[ "$line" == *"Disconnected from userid:"* ]]; then
+            [[ "${DISCORD_PLAYER_LEAVE_ENABLED,,}" == false ]] && continue
 
             # Extract steamid and reason
             steamid=$(echo "$line" | awk -F'[ :]+' '{print $4}')
@@ -34,7 +37,8 @@ LogParser() {
             SendDiscordMessage "$DISCORD_PLAYER_LEAVE_TITLE" "$message" "$DISCORD_PLAYER_LEAVE_COLOR"
         fi
 
-        if [[ "${DISCORD_SERVER_START_ENABLED,,}" == true ]] && [[ "$line" == "Started session with Game ID "* ]]; then
+        if [[ "$line" == "Started session with Game ID "* ]]; then
+            [[ "${DISCORD_SERVER_START_ENABLED,,}" == false ]] && continue
 
             # Extract Game ID
             gameid=$(echo "$line" | awk '{print $6}')


### PR DESCRIPTION
If any of DISCORD_PLAYER_JOIN_ENABLED, DISCORD_PLAYER_LEAVE_ENABLED, or DISCORD_SERVER_START_ENABLED were set to false, logfile-parser.sh would stop running when receiving any of those events. That's also why the stdout logs would stop on server start.

This fixes that by removing the `return 0` stuff which allows the script to continue running. We also aren't needlessly parsing lines if that specific notification is disabled.