### PR TITLE
Fix discord message server start game ID not being sent

### DIFF
--- a/scripts/logfile-parser.sh
+++ b/scripts/logfile-parser.sh
@@ -37,11 +37,11 @@ LogParser() {
             SendDiscordMessage "$DISCORD_PLAYER_LEAVE_TITLE" "$message" "$DISCORD_PLAYER_LEAVE_COLOR"
         fi
 
-        if [[ "$line" == "Started session with Game ID "* ]]; then
+        if [[ "$line" == "Started session with info: "* ]]; then
             [[ "${DISCORD_SERVER_START_ENABLED,,}" == false ]] && continue
 
             # Extract Game ID
-            gameid=$(echo "$line" | awk '{print $6}')
+            gameid=$(echo "$line" | awk '{print $5}')
 
             # Build message from vars and send message
             message=$(world_name="$WORLD_NAME" gameid="$gameid" envsubst <<<"$DISCORD_SERVER_START_MESSAGE")


### PR DESCRIPTION
Fixes #97, where the game ID wasn't being sent in the discord message on server start, as the log message line for game ID changed in game version 1.1.2.3:

Before 1.1.2.3:
```
core-keeper-dedicated  | Started session with Game ID test12345test12345
```

As of 1.1.2.3:
```
core-keeper-dedicated  | Started session with info: test12345test12345
```

Tested locally under WSL version: 2.4.13.0:
<img width="254" height="92" alt="image" src="https://github.com/user-attachments/assets/7efa9f4e-c6cd-4084-9f75-d62391e2cdee" />

