### PR TITLE
update README for valid game ID format

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ These are the arguments you can use to customize server behavior with default va
 | HASHED_WORLD_SEED | "" | The hashed seed to use for a new world, added in v1.1. Set to "" to generate random seed. |
 | WORLD_MODE | 0 | Sets the world mode for the world. Can be Normal (0), Hard (1), Creative (2), Casual (4). |
 | SEASON | No Default | Overrides current season by setting to any of None (0), Easter (1), Halloween (2), Christmas (3), Valentine (4), Anniversary (5), CherryBlossom (6), LunarNewYear(7).<br/>**Do not set this env var if you want real date season.** |
-| GAME_ID | "" |  Game ID to use for the server. Need to be at least 28 characters and alphanumeric, excluding Y,y,x,0,O. Empty or not valid means a new ID will be generated at start. |
+| GAME_ID | "" |  Game ID to use for the server. Need to be at least 15 characters, no longer than 28 characters and alphanumeric, excluding Y,y,x,0,O. Empty or not valid means a new ID will be generated at start. |
 | MAX_PLAYERS | 10 | Maximum number of players that will be allowed to connect to server. |
 | SERVER_IP | No Default | Only used if port is set. Sets the address that the server will bind to. |
 | SERVER_PORT | No Default | Port used for direct connection mode. **Setting an value to this will cause the server behaviour to change!** [See Network Mode](#network-mode) |

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ These are the arguments you can use to customize server behavior with default va
 | HASHED_WORLD_SEED | "" | The hashed seed to use for a new world, added in v1.1. Set to "" to generate random seed. |
 | WORLD_MODE | 0 | Sets the world mode for the world. Can be Normal (0), Hard (1), Creative (2), Casual (4). |
 | SEASON | No Default | Overrides current season by setting to any of None (0), Easter (1), Halloween (2), Christmas (3), Valentine (4), Anniversary (5), CherryBlossom (6), LunarNewYear(7).<br/>**Do not set this env var if you want real date season.** |
-| GAME_ID | "" |  Game ID to use for the server. Need to be at least 15 characters, no longer than 28 characters and alphanumeric, excluding Y,y,x,0,O. Empty or not valid means a new ID will be generated at start. |
+| GAME_ID | "" |  Game ID to use for the server. Need to be at least 15 characters, no longer than 28 characters and alphanumeric, excluding I,l,Y,y,x,0,O,o. Empty or not valid means a new ID will be generated at start. |
 | MAX_PLAYERS | 10 | Maximum number of players that will be allowed to connect to server. |
 | SERVER_IP | No Default | Only used if port is set. Sets the address that the server will bind to. |
 | SERVER_PORT | No Default | Port used for direct connection mode. **Setting an value to this will cause the server behaviour to change!** [See Network Mode](#network-mode) |


### PR DESCRIPTION
Closes #99

The current game version [1.1.2.3](https://store.steampowered.com/news/app/1621690/view/536609788663956850) changes the valid game ID format from [at least 28 characters ](https://github.com/escapingnetwork/core-keeper-dedicated/blob/44895e503c9dab198e5929f928690ff64c7eaf3b/README.md?plain=1#L99) to 15~28 characters according to the documentation in `/home/steam/core-keeper-dedicated/ARGUMENTS.txt` :
```
## Game ID

USAGE: -gameid ID

Select the game ID clients use to connect to this server. Game ID Needs to be at least 15 but at max 28 alphanumeric characters, and may not include Y,y,x,0, or O. If omitted or invalid, a random game ID will
be generated.

EXAMPLE: -gameid WH3rhzuk5TfbA4jFuZPg7SmbCHES
```

As this is an underlying change to the game, this can't be fixed within this repo. Possibly we can communicate this breaking change better in a dedicated readme section, as presumably most custom game IDs are no longer valid, as they would've needed to be exactly 28 characters.

Characters invalid in game IDs:

| Character | Notes        |
|-----------|--------------|
| `Y`       | Uppercase `Y`|
| `y`       | Lowercase `Y`|
| `x`       | Lowercase `X`|
| `0`       | Digit zero    |
| `O`       | Uppercase `O`|
| `o`       | Lowercase `O` (not mentioned in game docs)|
| `I`       | Uppercase `I` (not mentioned in game docs)|
| `l`       | Lowercase `L` (not mentioned in game docs)|