### PR TITLE
Version 1.1.2.3 - New launch parameters 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -107,6 +107,8 @@ ENV PUID=1000 \
     SEASON="" \
     SERVER_IP="" \
     SERVER_PORT="" \
+    PASSWORD="" \
+    ALLOW_ONLY_PLATFORM="" \
     DISCORD_WEBHOOK_URL="" \
     # Player Join
     DISCORD_PLAYER_JOIN_ENABLED=true \

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ These are the arguments you can use to customize server behavior with default va
 | HASHED_WORLD_SEED | "" | The hashed seed to use for a new world, added in v1.1. Set to "" to generate random seed. |
 | WORLD_MODE | 0 | Sets the world mode for the world. Can be Normal (0), Hard (1), Creative (2), Casual (4). |
 | SEASON | No Default | Overrides current season by setting to any of None (0), Easter (1), Halloween (2), Christmas (3), Valentine (4), Anniversary (5), CherryBlossom (6), LunarNewYear(7).<br/>**Do not set this env var if you want real date season.** |
-| GAME_ID | "" |  Game ID to use for the server. Need to be at least 28 characters and alphanumeric, excluding I,l,Y,y,x,0,O,o. Empty or not valid means a new ID will be generated at start. |
+| GAME_ID | "" |  Game ID to use for the server. Need to be at least 28 characters and alphanumeric, excluding Y,y,x,0,O. Empty or not valid means a new ID will be generated at start. |
 | MAX_PLAYERS | 10 | Maximum number of players that will be allowed to connect to server. |
 | SERVER_IP | No Default | Only used if port is set. Sets the address that the server will bind to. |
 | SERVER_PORT | No Default | Port used for direct connection mode. **Setting an value to this will cause the server behaviour to change!** [See Network Mode](#network-mode) |

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ These are the arguments you can use to customize server behavior with default va
 | HASHED_WORLD_SEED | "" | The hashed seed to use for a new world, added in v1.1. Set to "" to generate random seed. |
 | WORLD_MODE | 0 | Sets the world mode for the world. Can be Normal (0), Hard (1), Creative (2), Casual (4). |
 | SEASON | No Default | Overrides current season by setting to any of None (0), Easter (1), Halloween (2), Christmas (3), Valentine (4), Anniversary (5), CherryBlossom (6), LunarNewYear(7).<br/>**Do not set this env var if you want real date season.** |
-| GAME_ID | "" |  Game ID to use for the server. Need to be at least 28 characters and alphanumeric, excluding Y,y,x,0,O. Empty or not valid means a new ID will be generated at start. |
+| GAME_ID | "" |  Game ID to use for the server. Need to be at least 28 characters and alphanumeric, excluding I,l,Y,y,x,0,O,o. Empty or not valid means a new ID will be generated at start. |
 | MAX_PLAYERS | 10 | Maximum number of players that will be allowed to connect to server. |
 | SERVER_IP | No Default | Only used if port is set. Sets the address that the server will bind to. |
 | SERVER_PORT | No Default | Port used for direct connection mode. **Setting an value to this will cause the server behaviour to change!** [See Network Mode](#network-mode) |

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ These are the arguments you can use to customize server behavior with default va
 | SERVER_IP | No Default | Only used if port is set. Sets the address that the server will bind to. |
 | SERVER_PORT | No Default | Port used for direct connection mode. **Setting an value to this will cause the server behaviour to change!** [See Network Mode](#network-mode) |
 | PASSWORD | No Default | Password players should use when trying to join using direct connections. Maximum length password can be 28 characters. If omitted or invalid, a random password will be generated.|
-| ALLOW_ONLY_PLATFORM | No Default | Allow only players from given platform. If not set all platform are allowed. Has no effect unless -port is also set enabling Direct Connections. Can be Steam (1), Epic (2), Microsoft (3), GOG (4). |
+| ALLOW_ONLY_PLATFORM | No Default | Allow only players from given platform. If not set all platforms are allowed. Has no effect unless -port is also set enabling Direct Connections. Can be Steam (1), Epic (2), Microsoft (3), GOG (4). |
 | DISCORD_WEBHOOK_URL | "" | Webhook url (Edit channel > Integrations > Create Webhook). |
 | DISCORD_PLAYER_JOIN_ENABLED | true | Enable/Disable message on player join |
 | DISCORD_PLAYER_JOIN_MESSAGE | `"$${char_name} ($${steamid}) has joined the server."` | Embed message |

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ These are the arguments you can use to customize server behavior with default va
 | MAX_PLAYERS | 10 | Maximum number of players that will be allowed to connect to server. |
 | SERVER_IP | No Default | Only used if port is set. Sets the address that the server will bind to. |
 | SERVER_PORT | No Default | Port used for direct connection mode. **Setting an value to this will cause the server behaviour to change!** [See Network Mode](#network-mode) |
+| PASSWORD | No Default | Password players should use when trying to join using direct connections. Maximum length password can be 28 characters. If omitted or invalid, a random password will be generated.|
+| ALLOW_ONLY_PLATFORM | No Default | Allow players from given platform. Has no effect unless -port is also set enabling Direct Connections. Can be Steam (1), Epic (2), Microsoft (3), GOG (4).  |
 | DISCORD_WEBHOOK_URL | "" | Webhook url (Edit channel > Integrations > Create Webhook). |
 | DISCORD_PLAYER_JOIN_ENABLED | true | Enable/Disable message on player join |
 | DISCORD_PLAYER_JOIN_MESSAGE | `"$${char_name} ($${steamid}) has joined the server."` | Embed message |

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ These are the arguments you can use to customize server behavior with default va
 | SERVER_IP | No Default | Only used if port is set. Sets the address that the server will bind to. |
 | SERVER_PORT | No Default | Port used for direct connection mode. **Setting an value to this will cause the server behaviour to change!** [See Network Mode](#network-mode) |
 | PASSWORD | No Default | Password players should use when trying to join using direct connections. Maximum length password can be 28 characters. If omitted or invalid, a random password will be generated.|
-| ALLOW_ONLY_PLATFORM | No Default | Allow players from given platform. Has no effect unless -port is also set enabling Direct Connections. Can be Steam (1), Epic (2), Microsoft (3), GOG (4).  |
+| ALLOW_ONLY_PLATFORM | No Default | Allow only players from given platform. If not set all platform are allowed. Has no effect unless -port is also set enabling Direct Connections. Can be Steam (1), Epic (2), Microsoft (3), GOG (4). |
 | DISCORD_WEBHOOK_URL | "" | Webhook url (Edit channel > Integrations > Create Webhook). |
 | DISCORD_PLAYER_JOIN_ENABLED | true | Enable/Disable message on player join |
 | DISCORD_PLAYER_JOIN_MESSAGE | `"$${char_name} ($${steamid}) has joined the server."` | Embed message |

--- a/docker-compose-example/.env
+++ b/docker-compose-example/.env
@@ -10,8 +10,9 @@ GAME_ID=""
 MAX_PLAYERS=10
 SEASON=""
 SERVER_IP=""
-# Port is only needed if using direct connect mode
+# Port and Password are only needed if using direct connect mode
 #SERVER_PORT="27015"
+#PASSWORD=""
 DISCORD_WEBHOOK_URL=""
 # Player Join
 DISCORD_PLAYER_JOIN_ENABLED=true

--- a/scripts/compile-parameters.sh
+++ b/scripts/compile-parameters.sh
@@ -33,7 +33,7 @@ add_param "-season"     "${SEASON}"
 add_param "-ip"         "${SERVER_IP}"
 add_param "-port"       "${SERVER_PORT}"
 add_param "-activatecontent" "${ACTIVATE_CONTENT}"
-add_param "-password" "${PASSWORD}"
+add_param "-password"   "${PASSWORD}"
 add_param "-allowonlyplatform" "${ALLOW_ONLY_PLATFORM}"
 
 echo "${params[@]}"

--- a/scripts/compile-parameters.sh
+++ b/scripts/compile-parameters.sh
@@ -33,5 +33,7 @@ add_param "-season"     "${SEASON}"
 add_param "-ip"         "${SERVER_IP}"
 add_param "-port"       "${SERVER_PORT}"
 add_param "-activatecontent" "${ACTIVATE_CONTENT}"
+add_param "-password" "${PASSWORD}"
+add_param "-allowonlyplatform" "${ALLOW_ONLY_PLATFORM}"
 
 echo "${params[@]}"


### PR DESCRIPTION
The version 1.1.2.3 add the new launch parameters `-password` and `-allowonlyplatform`.

* https://github.com/escapingnetwork/core-keeper-dedicated/issues/72#issuecomment-3189720665
* https://github.com/escapingnetwork/core-keeper-dedicated/issues/72#issuecomment-3189745034

Also the generated file `GameID.txt` has changed and a new file `GameInfo.txt` is available. 

GameInfo.txt (tested on windows host, not verified on the docker image yet) 
```
Allowed platforms: All
GameID: abcdefghijkmn
Local IP: 192.168.1.100
Public IP: 87.*.*.*
Port: 27015
Password: zJk4DQ374w4PBG8

Paste to ip-field in "join via IP" menu to easily fill all values
87.*.*.*:27015::zJk4DQ374w4PBG8
```

