### PR TITLE
Upgrade Depot Downloader version to 3.4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ RUN case "${TARGETARCH}" in \
     esac
 
 # Download Depot downloader
-ARG DEPOT_DOWNLOADER_VERSION="2.7.4"
+ARG DEPOT_DOWNLOADER_VERSION="3.4.0"
 RUN case "${TARGETARCH}" in \
         "amd64") DEPOT_DOWNLOADER_FILENAME=DepotDownloader-linux-x64.zip ;; \
         "arm64") DEPOT_DOWNLOADER_FILENAME=DepotDownloader-linux-arm64.zip ;; \


### PR DESCRIPTION
Updated the Depot Downloader version from 2.7.4 to 3.4.0 in the Dockerfile.

Fixes the following issue:
<img width="1325" height="627" alt="testtest" src="https://github.com/user-attachments/assets/52b36752-609d-419d-b11b-773440217c4a" />


Tested on Mac Mini M1