### PR TITLE
Update ARM64 to `sonroyaalmerol/steamcmd-arm64:root-2026-02-15`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Dockerfile that builds a Core Keeper Gameserver
 ###########################################################
 FROM cm2network/steamcmd:root AS base-amd64
-FROM --platform=arm64 sonroyaalmerol/steamcmd-arm64:root-2025-04-13 AS base-arm64
+FROM --platform=arm64 sonroyaalmerol/steamcmd-arm64:root-2026-02-15 AS base-arm64
 
 ARG TARGETARCH
 FROM base-${TARGETARCH}


### PR DESCRIPTION
Update ARM64 base image from `sonroyaalmerol/steamcmd-arm64:root-2025-04-13` to `sonroyaalmerol/steamcmd-arm64:root-2026-02-15`

I would like to point out that the base image from `steamcmd-arm64` changed from `bookworm` to `trixie`. (`root-2026-01-09` was the first `trixie` based image). I am not sure if this will affect older systems.

Would be great if someone with an ARM system could verify this. 